### PR TITLE
Update Get-PnPWikiPageContent.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Get-PnPWikiPageContent.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Get-PnPWikiPageContent.md
@@ -71,6 +71,9 @@ Accept pipeline input: False
 
 ### System.String
 
+## NOTES
+Get-PnPWikiPageContent Cmdlet works with Modern Wiki Pages. It does not work with Wiki Pages created with Enterprise Wiki Site Template.
+
 ## RELATED LINKS
 
 [SharePoint Developer Patterns and Practices](https://aka.ms/sppnp)


### PR DESCRIPTION
Added Notes - section in the documentation because Get-PnPWikiPageContent Cmdlet does not work with Wiki Pages created with the Enterprise Wiki Site Template.